### PR TITLE
Removed use of undefined variables

### DIFF
--- a/scripts/make_netcdf.sh
+++ b/scripts/make_netcdf.sh
@@ -16,7 +16,7 @@ datadate=$1  # YYYYmmdd
 
 python ${SCRIPT_DIR}/../process_aws.py ${datapath}/${datadate}_vaisala.csv -m ${metadata_file} -o ${netcdf_path} -v
 
-if [ -f ${netcdf_path}/ncas-aws-10_iao_${year}${month}${day}_surface-met_*.nc ]
+if [ -f ${netcdf_path}/ncas-aws-10_iao_${datadate}_surface-met_*.nc ]
 then 
   aws_file_exists=True
 else


### PR DESCRIPTION
Fixed issue in `make_netcdf.sh` where script was search for file using year, month and day when those variables had not been defined (split apart from date variable).