### PR TITLE
Bug fixes

### DIFF
--- a/process_aws.py
+++ b/process_aws.py
@@ -68,8 +68,8 @@ def make_netcdf_surface_met(aws_file, metadata_file = None, ncfile_location = '.
         util.update_variable(ncfile, key, value)
     
     if verbose: print('Adding global attributes')
-    ncfile.setncattr('time_coverage_start', dt.datetime.fromtimestamp(time_coverage_start_dt, dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S %Z"))
-    ncfile.setncattr('time_coverage_end', dt.datetime.fromtimestamp(time_coverage_end_dt, dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S %Z"))
+    ncfile.setncattr('time_coverage_start', dt.datetime.fromtimestamp(time_coverage_start_dt, dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S"))
+    ncfile.setncattr('time_coverage_end', dt.datetime.fromtimestamp(time_coverage_end_dt, dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S"))
     
     util.add_metadata_to_netcdf(ncfile, metadata_file)
                 


### PR DESCRIPTION
Small fixes:
1. Remove timezone from `time_coverage_start` and `time_coverage_end` global attributes in accordance with NCAS-AMF-2.0.0 standard.
2. Change in template submodule to account for instance where there is a comma at the end of QC flag_values in the underlying spreadsheets. This affected at least `surface-met` products.